### PR TITLE
Change permissions of workflow job

### DIFF
--- a/.github/workflows/no-pr.yml
+++ b/.github/workflows/no-pr.yml
@@ -12,8 +12,7 @@ on:
 jobs:
   close-pull-request:
     runs-on: ubuntu-20.04
-    permissions:
-      pull-requests: write
+    permissions: write-all
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       PULL_REQUEST_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
# Changelog

The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).

## Fixed

- Change `permissions` of workflow job from `pull-requests: write` to `write-all`.

---

With `pull-requests: write`, the authorization error keeps happening.