### PR TITLE
Try to fix mirror CI

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Download and install Git LFS
         run: |
           sudo apt-get update
-          sudo apt-get install --assume-yes git-lfs=3.0.2-1ubuntu0.3
+          sudo apt-get install --assume-yes --allow-downgrades git-lfs=3.0.2-1ubuntu0.3
 
       - name: Clone remote repository
         run: git clone --branch ${{ github.ref }} ${{ inputs.repository-url }} source


### PR DESCRIPTION
# Changelog

The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).

## Fixed

- Add `--allow-downgrades` flag to `apt-get install` command to fix error when pinning version of `git-lfs` package.